### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ import { Fetcher, fetcher } from '@zero-dependency/fetcher'
 
 interface Post {
   id: number
-  userId: number
+  authorId: number
   title: string
   body: string
 }
 
 const api = new Fetcher('https://jsonplaceholder.typicode.com')
 const post = await api.get<Post>('/posts/1')
-console.log(post) // { id: 1, postId: 1, ... }
+console.log(post) // { id: 1, authorId: 1, ... }
 ```


### PR DESCRIPTION
Не очень логичный пример, что в ответе от сервера при запросе поста мы получаем id поста и postID.
Изменил пример ответа и заменил userId на authorId